### PR TITLE
Make the docstrings of World2 figures appear on the documentation

### DIFF
--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -36,48 +36,6 @@ Pages   = ["solvesystems.jl"]
 
 ## Reproducing World2 figures
 
-### Agriculture Investment system
-
-```@autodocs
-Modules = [WorldDynamics.World2.AgricultureInvestment]
-Pages   = ["plots.jl"]
-```
-
-### Capital Investment system
-
-```@autodocs
-Modules = [WorldDynamics.World2.CapitalInvestment]
-Pages   = ["plots.jl"]
-```
-
-### Natural Resources system
-
-```@autodocs
-Modules = [WorldDynamics.World2.NaturalResources]
-Pages   = ["plots.jl"]
-```
-
-### Pollution system
-
-```@autodocs
-Modules = [WorldDynamics.World2.Pollution]
-Pages   = ["plots.jl"]
-```
-
-### Population system
-
-```@autodocs
-Modules = [WorldDynamics.World2.Population]
-Pages   = ["plots.jl"]
-```
-
-### Quality Life system
-
-```@autodocs
-Modules = [WorldDynamics.World2.QualityLife]
-Pages   = ["plots.jl"]
-```
-
 ### World2 system
 
 ```@autodocs

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -43,6 +43,13 @@ Modules = [WorldDynamics.World2.AgricultureInvestment]
 Pages   = ["plots.jl"]
 ```
 
+### Capital Investment system
+
+```@autodocs
+Modules = [WorldDynamics.World2.CapitalInvestment]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -71,6 +71,13 @@ Modules = [WorldDynamics.World2.Population]
 Pages   = ["plots.jl"]
 ```
 
+### Pollution system
+
+```@autodocs
+Modules = [WorldDynamics.World2.Pollution]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -64,13 +64,6 @@ Modules = [WorldDynamics.World2.Pollution]
 Pages   = ["plots.jl"]
 ```
 
-### Pollution system
-
-```@autodocs
-Modules = [WorldDynamics.World2.Pollution]
-Pages   = ["plots.jl"]
-```
-
 ### Population system
 
 ```@autodocs

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -64,17 +64,17 @@ Modules = [WorldDynamics.World2.Pollution]
 Pages   = ["plots.jl"]
 ```
 
-### Population system
-
-```@autodocs
-Modules = [WorldDynamics.World2.Population]
-Pages   = ["plots.jl"]
-```
-
 ### Pollution system
 
 ```@autodocs
 Modules = [WorldDynamics.World2.Pollution]
+Pages   = ["plots.jl"]
+```
+
+### Population system
+
+```@autodocs
+Modules = [WorldDynamics.World2.Population]
 Pages   = ["plots.jl"]
 ```
 

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -85,6 +85,13 @@ Modules = [WorldDynamics.World2.QualityLife]
 Pages   = ["plots.jl"]
 ```
 
+### World2 system
+
+```@autodocs
+Modules = [WorldDynamics.World2.World2]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -64,6 +64,13 @@ Modules = [WorldDynamics.World2.Pollution]
 Pages   = ["plots.jl"]
 ```
 
+### Population system
+
+```@autodocs
+Modules = [WorldDynamics.World2.Population]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -57,6 +57,13 @@ Modules = [WorldDynamics.World2.NaturalResources]
 Pages   = ["plots.jl"]
 ```
 
+### Pollution system
+
+```@autodocs
+Modules = [WorldDynamics.World2.Pollution]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -50,6 +50,13 @@ Modules = [WorldDynamics.World2.CapitalInvestment]
 Pages   = ["plots.jl"]
 ```
 
+### Natural Resources system
+
+```@autodocs
+Modules = [WorldDynamics.World2.NaturalResources]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -88,7 +88,7 @@ Pages   = ["plots.jl"]
 ### World2 system
 
 ```@autodocs
-Modules = [WorldDynamics.World2.World2]
+Modules = [WorldDynamics.World2]
 Pages   = ["plots.jl"]
 ```
 

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -34,6 +34,15 @@ Order   = [:function]
 Pages   = ["solvesystems.jl"]
 ```
 
+## Reproducing World2 figures
+
+### Agriculture Investment system
+
+```@autodocs
+Modules = [WorldDynamics.World2.AgricultureInvestment]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system

--- a/docs/src/source.md
+++ b/docs/src/source.md
@@ -78,6 +78,13 @@ Modules = [WorldDynamics.World2.Population]
 Pages   = ["plots.jl"]
 ```
 
+### Quality Life system
+
+```@autodocs
+Modules = [WorldDynamics.World2.QualityLife]
+Pages   = ["plots.jl"]
+```
+
 ## Reproducing World3 figures
 
 ### Agriculture system


### PR DESCRIPTION
Should fix Issue #135 by adding the section "Reproducing World2 figures" to the documentation.