### PR TITLE
Add compatibility with ModelingToolkit 9

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.6'
+          version: '1.9'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.9'
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.9'
+          version: '1.10'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.6'
+          version: '1.9'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ DifferentialEquations = "7.1"
 IfElse = "0.1.1"
 ModelingToolkit = "9.0"
 PlotlyJS = "0.13 - 0.18.13"
-julia = "1.6 - 1.10.2"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -12,13 +12,13 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 
 [compat]
-ColorSchemes = "3.0 - 3.24"
-ColorTypes = "0.7 - 0.11.4"
-DifferentialEquations = "7.1 - 7.12"
+ColorSchemes = "3.0"
+ColorTypes = "0.7 - 0.11.5"
+DifferentialEquations = "7.1"
 IfElse = "0.1.1"
-ModelingToolkit = "8.26 - 8.75"
-PlotlyJS = "0.13 - 0.18.12"
-julia = "1.6 - 1.10"
+ModelingToolkit = "9.0"
+PlotlyJS = "0.13 - 0.18.13"
+julia = "1.6 - 1.10.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -217,7 +217,7 @@ function non_renewable_stock(; name, params=_params, inits=_inits, tables=_table
         maximum_investment ~ capital_funds / cost_per_investment
         investment ~ min(desired_investment, maximum_investment)
     ]
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 ```
 The arguments of the function are the dictionaries corresponding to the variable initial values and to the parameter values, and the dictionaries corresponding to the tables and the ranges used for the linear of non-linear functions. The first two dictionaries are used to assign a value to all the parameters and an initial value to two variables. The ODE system is a vector of differential and algebraic equations (as specified in the chapter of the above mentioned book). Note that the two differential equations correspond to the two variables whose initial value has been specified. The variable `extraction_efficiency_per_unit_capital` is defined as a linear interpolation of the variable `resource`, by using the table `tables[:eepuc]` together with the range `ranges[:eepuc]`. The table and the corresponding range are defined in the file `tables.jl`, which define two dictionaries as follows.

--- a/src/World1/world1/subsystems.jl
+++ b/src/World1/world1/subsystems.jl
@@ -104,5 +104,5 @@ function world1(; name, params=_params, inits=_inits, tables=_tables, ranges=_ra
         qlp ~ interpolate(polr, tables[:qlp], ranges[:qlp])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World1A/world1a/subsystems.jl
+++ b/src/World1A/world1a/subsystems.jl
@@ -8,5 +8,5 @@ function world1a(; name, params=_params, inits=_inits, tables=_tables, ranges=_r
         nrmm ~ interpolate(msl, tables[:nrmm], ranges[:nrmm])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World1B/world1b/subsystems.jl
+++ b/src/World1B/world1b/subsystems.jl
@@ -8,5 +8,5 @@ function world1b(; name, params=_params, inits=_inits, tables=_tables, ranges=_r
         ciqr ~ interpolate(qlm / qlf, tables[:ciqr], ranges[:ciqr])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World2/agricultureinvestment/subsystems.jl
+++ b/src/World2/agricultureinvestment/subsystems.jl
@@ -32,5 +32,5 @@ function agriculture_investment(; name, params=_params, inits=_inits, tables=_ta
         ciqr ~ interpolate(qlm / qlf, tables[:ciqr], ranges[:ciqr])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World2/capitalinvestment/subsystems.jl
+++ b/src/World2/capitalinvestment/subsystems.jl
@@ -25,7 +25,7 @@ function capital_investment(; name, params=_params, inits=_inits, tables=_tables
         D(ci) ~ cig - cid
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function capital_investment_generation(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -44,7 +44,7 @@ function capital_investment_generation(; name, params=_params, inits=_inits, tab
         cim ~ interpolate(msl, tables[:cim], ranges[:cim])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function capital_investment_discard(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -60,5 +60,5 @@ function capital_investment_discard(; name, params=_params, inits=_inits, tables
         cid ~ ci * clip(cidn, cidn1, swt5, t)
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World2/naturalresources/subsystems.jl
+++ b/src/World2/naturalresources/subsystems.jl
@@ -14,7 +14,7 @@ function natural_resources(; name, params=_params, inits=_inits, tables=_tables,
         D(nr) ~ -nrur
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function natural_resources_usage_rate(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -33,5 +33,5 @@ function natural_resources_usage_rate(; name, params=_params, inits=_inits, tabl
         nrmm ~ interpolate(msl, tables[:nrmm], ranges[:nrmm])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World2/pollution/subsystems.jl
+++ b/src/World2/pollution/subsystems.jl
@@ -15,7 +15,7 @@ function pollution(; name, params=_params, inits=_inits, tables=_tables, ranges=
         D(pol) ~ polg - pola
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function pollution_absorption(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -30,7 +30,7 @@ function pollution_absorption(; name, params=_params, inits=_inits, tables=_tabl
         polat ~ interpolate(polr, tables[:polat], ranges[:polat])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function pollution_generation(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -49,5 +49,5 @@ function pollution_generation(; name, params=_params, inits=_inits, tables=_tabl
         polcm ~ interpolate(cir, tables[:polcm], ranges[:polcm])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World2/population/subsystems.jl
+++ b/src/World2/population/subsystems.jl
@@ -16,7 +16,7 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         cr ~ p / (la * pdn)
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function birth_rate(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -44,7 +44,7 @@ function birth_rate(; name, params=_params, inits=_inits, tables=_tables, ranges
         brpm ~ interpolate(polr, tables[:brpm], ranges[:brpm])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function death_rate(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -72,5 +72,5 @@ function death_rate(; name, params=_params, inits=_inits, tables=_tables, ranges
         drpm ~ interpolate(polr, tables[:drpm], ranges[:drpm])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World2/qualitylife/subsystems.jl
+++ b/src/World2/qualitylife/subsystems.jl
@@ -23,5 +23,5 @@ function quality_life(; name, params=_params, inits=_inits, tables=_tables, rang
         qlp ~ interpolate(polr, tables[:qlp], ranges[:qlp])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/SupplementaryEquations.jl
+++ b/src/World3/SupplementaryEquations.jl
@@ -16,7 +16,7 @@ function supplementary_equations(; name)
         fos ~ so / (0.22 * f + so + io) # Line 149 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 

--- a/src/World3/agriculture/subsystems.jl
+++ b/src/World3/agriculture/subsystems.jl
@@ -14,7 +14,7 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         pop2 ~ popi * exp(exppop * (eyear - 1900.0))
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function industrial_output(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -31,7 +31,7 @@ function industrial_output(; name, params=_params, inits=_inits, tables=_tables,
         iopc ~ io / pop
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function persistent_pollution(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -46,7 +46,7 @@ function persistent_pollution(; name, params=_params, inits=_inits, tables=_tabl
         ppolx2 ~ ppolxi * exp(0.03 * (eyear - 1900.0))
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function land_development(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -79,7 +79,7 @@ function land_development(; name, params=_params, inits=_inits, tables=_tables, 
         dcph ~ interpolate(pal / palt, tables[:dcph], ranges[:dcph]) # Line 97 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function agricultural_inputs(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -107,7 +107,7 @@ function agricultural_inputs(; name, params=_params, inits=_inits, tables=_table
         lymap2 ~ interpolate(io / io70, tables[:lymap2], ranges[:lymap2]) # Line 106 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function investment_allocation_decision(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -123,7 +123,7 @@ function investment_allocation_decision(; name, params=_params, inits=_inits, ta
         mlymc ~ interpolate(aiph, tables[:mlymc], ranges[:mlymc]) # Line 111 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function land_erosion_urban_industrial_use(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -148,7 +148,7 @@ function land_erosion_urban_industrial_use(; name, params=_params, inits=_inits,
         D(uil) ~ lrui # Line 120 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function land_fertility_degradation(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -162,7 +162,7 @@ function land_fertility_degradation(; name, params=_params, inits=_inits, tables
         lfd ~ lfert * lfdr # Line 123 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function land_fertility_regeneration(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -176,7 +176,7 @@ function land_fertility_regeneration(; name, params=_params, inits=_inits, table
         lfrt ~ interpolate(falm, tables[:lfrt], ranges[:lfrt]) # Line 125 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function discontinuing_land_maintenance(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -193,5 +193,5 @@ function discontinuing_land_maintenance(; name, params=_params, inits=_inits, ta
         D(pfr) ~ (fr - pfr) / fspd # Line 128 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/capital/subsystems.jl
+++ b/src/World3/capital/subsystems.jl
@@ -10,7 +10,7 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         p3 ~ 0.25 * pop
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function agriculture(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -22,7 +22,7 @@ function agriculture(; name, params=_params, inits=_inits, tables=_tables, range
         fioaa ~ interpolate(t, tables[:fioaa], ranges[:fioaa])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function non_renewable(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -32,7 +32,7 @@ function non_renewable(; name, params=_params, inits=_inits, tables=_tables, ran
         fcaor ~ interpolate(t, tables[:fcaor], ranges[:fcaor])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function industrial_subsector(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -64,7 +64,7 @@ function industrial_subsector(; name, params=_params, inits=_inits, tables=_tabl
         fioacv ~ interpolate(iopc / iopcd, tables[:fioacv], ranges[:fioacv]) # Line 59 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function service_subsector(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -94,7 +94,7 @@ function service_subsector(; name, params=_params, inits=_inits, tables=_tables,
         scor ~ clip(scor2, scor1, t, pyear) # Line 72 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function job_subsector(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -120,5 +120,5 @@ function job_subsector(; name, params=_params, inits=_inits, tables=_tables, ran
         cuf ~ interpolate(lufd, tables[:cuf], ranges[:cuf]) # Line 83 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/nonrenewable/subsystems.jl
+++ b/src/World3/nonrenewable/subsystems.jl
@@ -14,7 +14,7 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         pop1 ~ popi * exp(gc * (t - 1900))
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function industrial_output(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -28,7 +28,7 @@ function industrial_output(; name, params=_params, inits=_inits, tables=_tables,
         iopc ~ io / pop
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function industrial_capital(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -47,7 +47,7 @@ function industrial_capital(; name, params=_params, inits=_inits, tables=_tables
         icdr ~ ic / alic
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function non_renewable(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -71,5 +71,5 @@ function non_renewable(; name, params=_params, inits=_inits, tables=_tables, ran
         fcaor2 ~ interpolate(nrfr, tables[:fcaor2], ranges[:fcaor2]) # Line 136 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/pollution/subsystems.jl
+++ b/src/World3/pollution/subsystems.jl
@@ -8,7 +8,7 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         pop ~ interpolate(t, tables[:pop], ranges[:pop]) * 1e8
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function non_renewable(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -18,7 +18,7 @@ function non_renewable(; name, params=_params, inits=_inits, tables=_tables, ran
         pcrum ~ interpolate(t, tables[:pcrum], ranges[:pcrum]) * 1e-2
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function agriculture(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -30,17 +30,17 @@ function agriculture(; name, params=_params, inits=_inits, tables=_tables, range
         al ~ interpolate(t, tables[:al], ranges[:al]) * 1e8
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function persistent_pollution_dummy(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
-    @variables ppgf22(t) 
+    @variables ppgf22(t)
 
     eqs = [
         ppgf22 ~ 1.0
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function persistent_pollution(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -90,7 +90,7 @@ function persistent_pollution(; name, params=_params, inits=_inits, tables=_tabl
         ahl ~ ahl70 * ahlm # Line 146 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function pollution_damage(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -111,7 +111,7 @@ function pollution_damage(; name, params=_params, inits=_inits, tables=_tables, 
         lfdr2 ~ interpolate(ppolx, tables[:lfdr2], ranges[:lfdr2])
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function adaptive_technological_control_cards(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -143,5 +143,5 @@ function adaptive_technological_control_cards(; name, params=_params, inits=_ini
         D(plmp1) ~ 3 * (lmp - plmp1) / pd
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/population/common_pop/subsystems.jl
+++ b/src/World3/population/common_pop/subsystems.jl
@@ -10,8 +10,8 @@ function death_rate(; name, params=_params, inits=_inits, tables=_tables, ranges
     @variables dr(t) pop(t)
     @variables fpc(t) sopc(t) iopc(t) ppolx(t)
     @variables ehspc(t) = inits[:hsapc] # Line 22 Appendix A
-    @variables fpu(t) = inits[:fpu] 
-    @variables lmf(t) = inits[:lmf] 
+    @variables fpu(t) = inits[:fpu]
+    @variables lmf(t) = inits[:lmf]
     @variables cmi(t) = inits[:cmi]
     @variables cdr(t) le(t)  hsapc(t) lmhs(t) lmhs1(t) lmhs2(t)  lmc(t) lmp(t)
 
@@ -30,7 +30,7 @@ function death_rate(; name, params=_params, inits=_inits, tables=_tables, ranges
         lmp ~ interpolate(ppolx, tables[:lmp], ranges[:lmp]) # Line 29 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function birth_rate(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -87,7 +87,7 @@ function birth_rate(; name, params=_params, inits=_inits, tables=_tables, ranges
         fsafc ~ interpolate(nfc, tables[:fsafc], ranges[:fsafc]) # Line 48 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function industrial_output(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -107,7 +107,7 @@ function industrial_output(; name, params=_params, inits=_inits, tables=_tables,
         iopc ~ io / pop
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function service_output(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -127,7 +127,7 @@ function service_output(; name, params=_params, inits=_inits, tables=_tables, ra
         sopc ~ so / pop
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function persistent_pollution(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -140,7 +140,7 @@ function persistent_pollution(; name, params=_params, inits=_inits, tables=_tabl
         D(ppolx) ~ WorldDynamics.step(t, ps, pt)
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end
 
 function food(; name, params=_params, inits=_inits, tables=_tables, ranges=_ranges)
@@ -160,5 +160,5 @@ function food(; name, params=_params, inits=_inits, tables=_tables, ranges=_rang
         fpc ~ f / pop
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/population/pop1/subsystems.jl
+++ b/src/World3/population/pop1/subsystems.jl
@@ -23,5 +23,5 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         br ~ clip(dr, tf * pop * ffw / rlt, t, pet)
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/population/pop15/subsystems.jl
+++ b/src/World3/population/pop15/subsystems.jl
@@ -133,5 +133,5 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         br ~ clip(dr, (tf / 10.0) * extra, t, pet)
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/population/pop4/subsystems.jl
+++ b/src/World3/population/pop4/subsystems.jl
@@ -42,5 +42,5 @@ function population(; name, params=_params, inits=_inits, tables=_tables, ranges
         br ~ clip(dr, tf * p2 * 0.5 / rlt, t, pet) # Line 30 Appendix A
     ]
 
-    ODESystem(eqs; name)
+    ODESystem(eqs, t; name)
 end

--- a/src/World3/world3/plots.jl
+++ b/src/World3/world3/plots.jl
@@ -621,7 +621,7 @@ function exponentially_growing_technologies(; name)
         expon ~ clip(alpha * (t - pyear), 0, t, pyear)
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 """
@@ -697,7 +697,7 @@ function resource_control(; name,
         nrcm ~ interpolate(1.0 - (nrur / dnrur), tables[:nrcm], ranges[:nrcm])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 function yield_control(; name,
@@ -721,7 +721,7 @@ function yield_control(; name,
         lycm ~ interpolate(drf - fr, tables[:lycm], ranges[:lycm])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 function pollution_control(; name,
@@ -745,7 +745,7 @@ function pollution_control(; name,
         polgfm ~ interpolate(1.0 - (ppolx / dpolx), tables[:polgfm], ranges[:polgfm])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 """
@@ -793,7 +793,7 @@ function fig_24(; kwargs...)
     new_equations[177] = ai.lyf ~ clip(yc.lyf2, ai.lyf1, t, ai.pyear)
     new_equations[215] = pp.ppgf ~ clip(pc.ppgf2, pp.ppgf1, t, pp.pyear)
 
-    @named _new_system = ODESystem(vcat(new_equations, connection_eqs))
+    @named _new_system = ODESystem(vcat(new_equations, connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, rc, yc, pc)
 
     solution = solve(new_system, (1900, 2100))
@@ -848,7 +848,7 @@ function fig_26(; kwargs...)
     new_equations[177] = ai.lyf ~ clip(yc.lyf2, ai.lyf1, t, ai.pyear)
     new_equations[215] = pp.ppgf ~ clip(pc.ppgf2, pp.ppgf1, t, pp.pyear)
 
-    @named _new_system = ODESystem(vcat(new_equations, connection_eqs))
+    @named _new_system = ODESystem(vcat(new_equations, connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, rc, yc, pc)
 
     solution = solve(new_system, (1900, 2100))
@@ -881,7 +881,7 @@ function technological_costs(; name,
         coym ~ interpolate(lyf2, tables[:coym], ranges[:coym])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 """
@@ -935,7 +935,7 @@ function fig_27(; kwargs...)
     new_equations[215] = pp.ppgf ~ clip(pc.ppgf2, pp.ppgf1, t, pp.pyear)
     new_equations[125] = is.icor ~ clip(tc.icor2, is.icor1, t, is.pyear)
 
-    @named _new_system = ODESystem(vcat(new_equations, connection_eqs))
+    @named _new_system = ODESystem(vcat(new_equations, connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, rc, yc, pc, tc)
 
     solution = solve(new_system, (1900, 2100))
@@ -972,7 +972,7 @@ function delayed_resource_control(; name,
         nrcm ~ interpolate(1.0 - (nrur / dnrur), tables[:nrcm], ranges[:nrcm])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 function delayed_yield_control(; name,
@@ -1003,7 +1003,7 @@ function delayed_yield_control(; name,
         lycm ~ interpolate(drf - fr, tables[:lycm], ranges[:lycm])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 function delayed_pollution_control(; name,
@@ -1034,7 +1034,7 @@ function delayed_pollution_control(; name,
         polgfm ~ interpolate(1.0 - (ppolx / dpolx), tables[:polgfm], ranges[:polgfm])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 """
@@ -1088,7 +1088,7 @@ function fig_30(; kwargs...)
     new_equations[215] = pp.ppgf ~ clip(dpc.ppgf2, pp.ppgf1, t, pp.pyear)
     new_equations[125] = is.icor ~ clip(tc.icor2, is.icor1, t, is.pyear)
 
-    @named _new_system = ODESystem(vcat(new_equations, connection_eqs))
+    @named _new_system = ODESystem(vcat(new_equations, connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, drc, dyc, dpc, tc)
 
     solution = solve(new_system, (1900, 2100))
@@ -1114,7 +1114,7 @@ function growth_bias(; name,
         D(siopc) ~ (iopc - siopc) / 2
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 """
@@ -1172,7 +1172,7 @@ function fig_32(; kwargs...)
     new_equations[215] = pp.ppgf ~ clip(dpc.ppgf2, pp.ppgf1, t, pp.pyear)
     new_equations[125] = is.icor ~ clip(tc.icor2, is.icor1, t, is.pyear)
 
-    @named _new_system = ODESystem(vcat(new_equations, connection_eqs))
+    @named _new_system = ODESystem(vcat(new_equations, connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, drc, dyc, dpc, tc, gb)
 
     growth_equations = equations(new_system)
@@ -1396,7 +1396,7 @@ function fig_39(; kwargs...)
     new_equations[215] = pp.ppgf ~ clip(dpc.ppgf2, pp.ppgf1, t, pp.pyear)
     new_equations[125] = is.icor ~ clip(tc.icor2, is.icor1, t, is.pyear)
 
-    @named _new_system = ODESystem(vcat(new_equations, connection_eqs))
+    @named _new_system = ODESystem(vcat(new_equations, connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, drc, dyc, dpc, tc)
 
     solution = solve(new_system, (1900, 2100))
@@ -1477,7 +1477,7 @@ function fig_41(; kwargs...)
     new_equations[215] = pp.ppgf ~ clip(dpc.ppgf2, pp.ppgf1, t, pp.pyear)
     new_equations[125] = is.icor ~ clip(tc.icor2, is.icor1, t, is.pyear)
 
-    @named _new_system = ODESystem(vcat(new_equations, connection_eqs))
+    @named _new_system = ODESystem(vcat(new_equations, connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, drc, dyc, dpc, tc)
 
     solution = solve(new_system, (1900, 2100))

--- a/src/World3_03/NewEquations.jl
+++ b/src/World3_03/NewEquations.jl
@@ -36,7 +36,7 @@ function human_welfare_index(; name,
         gdppc ~ interpolate(iopc / gdpu, tables[:gdppc], ranges[:gdppc])
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 function human_ecological_footprint(; name,
@@ -61,7 +61,7 @@ function human_ecological_footprint(; name,
         ulgha ~ uil / hgha
     ]
 
-    return ODESystem(eqs; name)
+    return ODESystem(eqs, t; name)
 end
 
 

--- a/src/World3_03/world3_03/scenarios.jl
+++ b/src/World3_03/world3_03/scenarios.jl
@@ -20,7 +20,7 @@ function scenario1(; kwargs...)
         hef.uil ~ leuiu.uil
     ]
 
-    @named _new_system = ODESystem(vcat(equations(system), connection_eqs))
+    @named _new_system = ODESystem(vcat(equations(system), connection_eqs), t)
     @named new_system = ModelingToolkit.compose(_new_system, hwi, hef)
 
     return new_system

--- a/src/solvesystems.jl
+++ b/src/solvesystems.jl
@@ -47,9 +47,9 @@ function variable_connections(systems::Vector{ODESystem})
     for u in eachindex(al)
         @assert length(al[u]) <= 1 "Error in the variable dependencies binary graph: one node has more than one neighbor"
         if (length(al[u]) > 0)
-            s, v = split(string(states(model)[u]), "₊")
+            s, v = split(string(unknowns(model)[u]), "₊")
             var2sys[v] = s
-            var2fullvar[v] = states(model)[u]
+            var2fullvar[v] = unknowns(model)[u]
         end
     end
     ed = equation_dependencies(model)


### PR DESCRIPTION
Hi!

This PR adds compatibility with the latest major release of ModelingToolkit (v9).

Since test coverage is not very high, please make sure nothing broke with my changes. 

Also, before merging, similar changes need to be made to the Earth4all repo (see worlddynamics/Earth4All.jl/pull/16), as it depends on this one.

Closes #208 

Best